### PR TITLE
Add support to specify HTTP client transport with request config

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -12,7 +12,7 @@ type Environment struct {
 	SiteName        string
 	ChargebeeDomain string
 	Protocol        string
-	Transport       http.RoundTripper
+	HTTPClient      *http.Client
 }
 
 var (

--- a/environment.go
+++ b/environment.go
@@ -3,6 +3,7 @@ package chargebee
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -11,6 +12,7 @@ type Environment struct {
 	SiteName        string
 	ChargebeeDomain string
 	Protocol        string
+	Transport       http.RoundTripper
 }
 
 var (

--- a/http_request.go
+++ b/http_request.go
@@ -10,8 +10,12 @@ import (
 var httpClient = &http.Client{Timeout: DefaultHTTPTimeout}
 
 //Do is used to execute an API Request.
-func Do(req *http.Request) (string, error) {
-	response, err := httpClient.Do(req)
+func Do(req *http.Request, env Environment) (string, error) {
+	client := httpClient
+	if env.HTTPClient != nil {
+		client = env.HTTPClient
+	}
+	response, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/http_util.go
+++ b/http_util.go
@@ -68,6 +68,9 @@ func newRequest(env Environment, method string, path string, body io.Reader, hea
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
+	if env.Transport != nil {
+		httpClient.Transport = env.Transport
+	}
 	path = env.apiBaseUrl() + path
 	httpReq, err := http.NewRequest(method, path, body)
 	if err != nil {

--- a/http_util.go
+++ b/http_util.go
@@ -68,9 +68,6 @@ func newRequest(env Environment, method string, path string, body io.Reader, hea
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	if env.Transport != nil {
-		httpClient.Transport = env.Transport
-	}
 	path = env.apiBaseUrl() + path
 	httpReq, err := http.NewRequest(method, path, body)
 	if err != nil {

--- a/list_request.go
+++ b/list_request.go
@@ -10,7 +10,7 @@ func (request RequestObj) ListRequestWithEnv(env Environment) (*ResultList, erro
 	if err != nil {
 		panic(err)
 	}
-	res, err1 := Do(req)
+	res, err1 := Do(req, env)
 	result := &ResultList{}
 	if err1 != nil {
 		return result, err1

--- a/request.go
+++ b/request.go
@@ -17,7 +17,7 @@ func (request RequestObj) RequestWithEnv(env Environment) (*Result, error) {
 	if err != nil {
 		panic(err)
 	}
-	res, err1 := Do(req)
+	res, err1 := Do(req, env)
 	result := &Result{}
 	if err1 != nil {
 		return result, err1


### PR DESCRIPTION
we can use these changes from the CB integration by specifying the `transport` along with the request config.

```
func NewAPI(site, key string, tp http.RoundTripper) *API {
	return &API{
		&chargebee.Environment{
			SiteName:  site,
			Key:       key,
			Transport: tp,
		},
	}
}
```